### PR TITLE
RFC: Automatic repair on replication factor changes

### DIFF
--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -133,6 +133,9 @@ public class AutoRepair
             AutoRepairConfig config = DatabaseDescriptor.getAutoRepairConfig();
             AutoRepairUtils.setup();
 
+            // Register RF change listener for automatic repair scheduling
+            org.apache.cassandra.schema.Schema.instance.registerListener(new ReplicationFactorChangeListener());
+
             for (AutoRepairConfig.RepairType repairType : AutoRepairConfig.RepairType.values())
             {
                 if (config.isAutoRepairEnabled(repairType))

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
@@ -399,6 +399,25 @@ public class AutoRepairUtils
         logger.info("Set force repair repair type: {}, node: {}", repairType, hostId);
     }
 
+    /**
+     * Force repair for all nodes in the cluster for a specific keyspace due to RF change.
+     * This ensures data consistency after replication factor modifications.
+     */
+    public static void setForceRepairForKeyspace(RepairType repairType, String keyspaceName, String reason)
+    {
+        logger.info("Scheduling force repair for keyspace {} due to: {}", keyspaceName, reason);
+        
+        // Force repair on all nodes in the cluster
+        TreeSet<UUID> allNodes = getHostIdsInCurrentRing(repairType);
+        for (UUID hostId : allNodes)
+        {
+            setForceRepair(repairType, hostId);
+        }
+        
+        logger.info("Scheduled force repair for {} nodes in keyspace {} (reason: {})", 
+                   allNodes.size(), keyspaceName, reason);
+    }
+
     public static long getLastRepairTimeForNode(RepairType repairType, UUID hostId)
     {
         ResultMessage.Rows rows = selectLastRepairTimeForNode.execute(QueryState.forInternalCalls(),

--- a/src/java/org/apache/cassandra/repair/autorepair/ReplicationFactorChangeListener.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/ReplicationFactorChangeListener.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.repair.autorepair;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.locator.NetworkTopologyStrategy;
+import org.apache.cassandra.locator.ReplicationFactor;
+import org.apache.cassandra.locator.SimpleStrategy;
+import org.apache.cassandra.schema.KeyspaceMetadata;
+import org.apache.cassandra.schema.SchemaChangeListener;
+import org.apache.cassandra.service.AutoRepairService;
+
+/**
+ * Listens for keyspace replication factor changes and triggers appropriate repair actions.
+ */
+public class ReplicationFactorChangeListener implements SchemaChangeListener
+{
+    private static final Logger logger = LoggerFactory.getLogger(ReplicationFactorChangeListener.class);
+
+    @Override
+    public void onAlterKeyspace(KeyspaceMetadata before, KeyspaceMetadata after)
+    {
+        if (!AutoRepairService.instance.getAutoRepairConfig().isAutoRepairSchedulingEnabled())
+        {
+            logger.debug("Auto-repair is disabled, skipping RF change detection");
+            return;
+        }
+
+        RFChangeAnalysis analysis = analyzeRFChange(before, after);
+        if (analysis.hasChanged)
+        {
+            logger.info("Detected RF change for keyspace {}: {}", after.name, analysis);
+            scheduleRepairForRFChange(after.name, analysis);
+        }
+    }
+
+    private RFChangeAnalysis analyzeRFChange(KeyspaceMetadata before, KeyspaceMetadata after)
+    {
+        RFChangeAnalysis analysis = new RFChangeAnalysis();
+        
+        if (before.params.replication.klass.equals(after.params.replication.klass))
+        {
+            if (after.params.replication.klass.equals(NetworkTopologyStrategy.class))
+            {
+                analysis = analyzeNTSChange(before.params.replication.options, after.params.replication.options);
+            }
+            else if (after.params.replication.klass.equals(SimpleStrategy.class))
+            {
+                analysis = analyzeSimpleStrategyChange(before.params.replication.options, after.params.replication.options);
+            }
+        }
+        else
+        {
+            // Strategy class changed - treat as RF change
+            analysis.hasChanged = true;
+            analysis.changeType = RFChangeType.STRATEGY_CHANGE;
+        }
+        
+        return analysis;
+    }
+
+    private RFChangeAnalysis analyzeNTSChange(Map<String, String> beforeOptions, Map<String, String> afterOptions)
+    {
+        RFChangeAnalysis analysis = new RFChangeAnalysis();
+        
+        Set<String> beforeDCs = beforeOptions.keySet();
+        Set<String> afterDCs = afterOptions.keySet();
+        
+        // Check for new DCs
+        for (String dc : afterDCs)
+        {
+            if (!beforeDCs.contains(dc))
+            {
+                analysis.hasChanged = true;
+                analysis.changeType = RFChangeType.NEW_DC_ADDED;
+                analysis.newDatacenters.add(dc);
+            }
+        }
+        
+        // Check for RF changes in existing DCs
+        for (String dc : beforeDCs)
+        {
+            if (afterDCs.contains(dc))
+            {
+                ReplicationFactor beforeRF = ReplicationFactor.fromString(beforeOptions.get(dc));
+                ReplicationFactor afterRF = ReplicationFactor.fromString(afterOptions.get(dc));
+                
+                if (beforeRF.allReplicas != afterRF.allReplicas)
+                {
+                    analysis.hasChanged = true;
+                    if (afterRF.allReplicas > beforeRF.allReplicas)
+                    {
+                        analysis.changeType = RFChangeType.RF_INCREASED;
+                    }
+                    else
+                    {
+                        analysis.changeType = RFChangeType.RF_DECREASED;
+                    }
+                }
+            }
+        }
+        
+        return analysis;
+    }
+
+    private RFChangeAnalysis analyzeSimpleStrategyChange(Map<String, String> beforeOptions, Map<String, String> afterOptions)
+    {
+        RFChangeAnalysis analysis = new RFChangeAnalysis();
+        
+        String beforeRFStr = beforeOptions.get("replication_factor");
+        String afterRFStr = afterOptions.get("replication_factor");
+        
+        if (beforeRFStr != null && afterRFStr != null)
+        {
+            int beforeRF = Integer.parseInt(beforeRFStr);
+            int afterRF = Integer.parseInt(afterRFStr);
+            
+            if (beforeRF != afterRF)
+            {
+                analysis.hasChanged = true;
+                analysis.changeType = afterRF > beforeRF ? RFChangeType.RF_INCREASED : RFChangeType.RF_DECREASED;
+            }
+        }
+        
+        return analysis;
+    }
+
+    private void scheduleRepairForRFChange(String keyspaceName, RFChangeAnalysis analysis)
+    {
+        switch (analysis.changeType)
+        {
+            case NEW_DC_ADDED:
+                logger.info("New DC added to keyspace {}, consider running rebuild instead of repair", keyspaceName);
+                // For new DC, rebuild is more efficient than repair, but we'll still schedule repair as fallback
+                scheduleFullRepair(keyspaceName, "New datacenter added");
+                break;
+                
+            case RF_INCREASED:
+                logger.info("RF increased for keyspace {}, scheduling full repair", keyspaceName);
+                scheduleFullRepair(keyspaceName, "Replication factor increased");
+                break;
+                
+            case RF_DECREASED:
+                logger.info("RF decreased for keyspace {}, scheduling full repair. Consider running cleanup manually.", keyspaceName);
+                scheduleFullRepair(keyspaceName, "Replication factor decreased");
+                break;
+                
+            case STRATEGY_CHANGE:
+                logger.info("Replication strategy changed for keyspace {}, scheduling full repair", keyspaceName);
+                scheduleFullRepair(keyspaceName, "Replication strategy changed");
+                break;
+        }
+    }
+
+    private void scheduleFullRepair(String keyspaceName, String reason)
+    {
+        // Force repair for all nodes to ensure consistency after RF change
+        AutoRepairUtils.setForceRepairForKeyspace(AutoRepairConfig.RepairType.FULL, keyspaceName, reason);
+    }
+
+    private static class RFChangeAnalysis
+    {
+        boolean hasChanged = false;
+        RFChangeType changeType;
+        Set<String> newDatacenters = new java.util.HashSet<>();
+        
+        @Override
+        public String toString()
+        {
+            return String.format("RFChangeAnalysis{hasChanged=%s, changeType=%s, newDatacenters=%s}", 
+                               hasChanged, changeType, newDatacenters);
+        }
+    }
+
+    private enum RFChangeType
+    {
+        RF_INCREASED,
+        RF_DECREASED,
+        NEW_DC_ADDED,
+        STRATEGY_CHANGE
+    }
+}

--- a/test/unit/org/apache/cassandra/repair/autorepair/ReplicationFactorChangeListenerTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/ReplicationFactorChangeListenerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.repair.autorepair;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.apache.cassandra.locator.NetworkTopologyStrategy;
+import org.apache.cassandra.schema.KeyspaceMetadata;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.apache.cassandra.schema.ReplicationParams;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ReplicationFactorChangeListenerTest
+{
+    @Test
+    public void testNTSRFIncrease()
+    {
+        ReplicationFactorChangeListener listener = new ReplicationFactorChangeListener();
+        
+        Map<String, String> beforeOptions = new HashMap<>();
+        beforeOptions.put("dc1", "2");
+        beforeOptions.put("dc2", "1");
+        
+        Map<String, String> afterOptions = new HashMap<>();
+        afterOptions.put("dc1", "3");  // RF increased
+        afterOptions.put("dc2", "1");
+        
+        KeyspaceMetadata before = createKeyspace("test_ks", beforeOptions);
+        KeyspaceMetadata after = createKeyspace("test_ks", afterOptions);
+        
+        // This would normally trigger repair scheduling
+        listener.onAlterKeyspace(before, after);
+    }
+    
+    @Test
+    public void testNTSNewDCAdded()
+    {
+        ReplicationFactorChangeListener listener = new ReplicationFactorChangeListener();
+        
+        Map<String, String> beforeOptions = new HashMap<>();
+        beforeOptions.put("dc1", "2");
+        
+        Map<String, String> afterOptions = new HashMap<>();
+        afterOptions.put("dc1", "2");
+        afterOptions.put("dc2", "1");  // New DC added
+        
+        KeyspaceMetadata before = createKeyspace("test_ks", beforeOptions);
+        KeyspaceMetadata after = createKeyspace("test_ks", afterOptions);
+        
+        listener.onAlterKeyspace(before, after);
+    }
+    
+    private KeyspaceMetadata createKeyspace(String name, Map<String, String> replicationOptions)
+    {
+        ReplicationParams replication = ReplicationParams.nts(replicationOptions);
+        KeyspaceParams params = KeyspaceParams.create(false, replication);
+        return KeyspaceMetadata.create(name, params);
+    }
+}


### PR DESCRIPTION
## Overview

This PR introduces a high-level proposal for automatically triggering repairs when keyspace replication factors change to ensure data consistency.

See issue: https://issues.apache.org/jira/browse/CASSANDRA-20582

## Implementation

### Key Components
- **ReplicationFactorChangeListener**: Detects RF changes via schema change events
- **Extended AutoRepairUtils**: Added  method  
- **AutoRepair Integration**: Registers listener during setup

### Supported Scenarios
- **RF Increase (same DCs)** → Full Repair
- **New DC Addition** → Full Repair (with rebuild recommendation logged)
- **RF Decrease** → Full Repair (with cleanup recommendation logged)
- **Strategy Changes** → Full Repair

## Known Limitations (Seeking Feedback)

This is intentionally a **minimal implementation** to gather feedback before building the complete solution:

1. **No Configuration**: Missing config flag to enable/disable the feature
2. **Repair vs Rebuild**: Uses repair instead of rebuild for new DC scenarios (rebuild is more efficient)
3. **No Per-Keyspace Options**: No way to customize behavior per keyspace
4. **Basic Error Handling**: Minimal error handling and logging

## Questions for Review

1. **Configuration Approach**: Should this be:
   - Global on/off flag in cassandra.yaml?
   - Per-keyspace table property?
   - Both?

2. **Rebuild Integration**: For new DC scenarios:
   - Should we integrate with existing rebuild functionality?
   - How to handle mixed scenarios (RF increase + new DC)?

3. **Operational Concerns**:
   - Should we add delays/throttling for large RF changes?
   - How to handle rapid successive RF changes?
   - Metrics and observability requirements?

4. **Scope**: Are there other RF change scenarios we should consider?

## Testing

Basic unit tests included. Integration testing will be added based on feedback.

---

**This PR is intended as an RFC to gather feedback before implementing the complete solution.**